### PR TITLE
fix: dependencie

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Requests==2.32.3
 sqlparse==0.5.1
 tabulate==0.9.0
 tqdm==4.66.5
+halo==0.0.31


### PR DESCRIPTION
Halo module: https://pypi.org/project/halo/
It is not coming during new installation with `pip install -r requirements.txt`